### PR TITLE
Fixes to configure.py

### DIFF
--- a/pattoo_shared/installation/configure.py
+++ b/pattoo_shared/installation/configure.py
@@ -82,6 +82,15 @@ Insufficient permissions for reading the file:{}'''.format(filepath))
             with f_handle:
                 yaml_string = f_handle.read()
                 config = yaml.safe_load(yaml_string)
+
+        # Find and replace dictionary values
+        for default_key in default_config:
+            for key in config:
+                if key == default_key:
+                    config[key] = default_config.get(default_key)
+            if default_key not in config:
+                config[default_key] = default_config.get(default_key)
+
     else:
         config = default_config
 

--- a/pattoo_shared/installation/configure.py
+++ b/pattoo_shared/installation/configure.py
@@ -88,6 +88,7 @@ Insufficient permissions for reading the file:{}'''.format(filepath))
             for key in config:
                 if key == default_key:
                     config[key] = default_config.get(default_key)
+            # Add new entries to config dict if they aren't in the file
             if default_key not in config:
                 config[default_key] = default_config.get(default_key)
 

--- a/pattoo_shared/installation/shared.py
+++ b/pattoo_shared/installation/shared.py
@@ -72,7 +72,8 @@ Bug: Exception Type:{}, Exception Instance: {}, Stack Trace Object: {}]\
             print('messages: {}'.format(messages))
         if bool(messages) is True:
             for log_message in messages:
-                print(log_message)
+                if verbose is True:
+                    print(log_message)
 
             if bool(die) is True:
                 # All done

--- a/pattoo_shared/installation/systemd.py
+++ b/pattoo_shared/installation/systemd.py
@@ -368,6 +368,7 @@ def install(daemon_list, template_dir, installation_dir, verbose=False):
     shared.run_script('systemctl daemon-reload', verbose=verbose)
 
     # Loop through daemon list and start daemons
+    print('Starting daemons')
     for daemon in daemon_list:
         daemon_check(daemon, verbose=verbose)
         start_daemon(daemon, verbose=verbose)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     python_requires='>=3.6',
 
     # Set up the version
-    version='0.0.92',
+    version='0.0.93',
 
     # Dependencies
     install_requires=[

--- a/tests/test_pattoo_shared/installation/test_configure.py
+++ b/tests/test_pattoo_shared/installation/test_configure.py
@@ -65,6 +65,31 @@ class TestConfigure(unittest.TestCase):
             }
         }
 
+        cls.custom_config = {
+            'encryption': {
+                'api_email': 'api_email@example.org',
+            },
+            'pattoo': {
+                'language': 'en',
+                'log_directory': (
+                    '/var/log/pattoo'),
+                'log_level': 'debug',
+                'cache_directory': (
+                    '/opt/pattoo-cache'),
+                'daemon_directory': (
+                    '/opt/pattoo-daemon'),
+                'system_daemon_directory': '/var/run/pattoo'
+            },
+            'pattoo_agent_api': {
+                'ip_address': '127.0.0.1',
+                'ip_bind_port': 20201
+            },
+            'pattoo_web_api': {
+                'ip_address': '127.0.0.1',
+                'ip_bind_port': 20202,
+            }
+        }
+
         cls.default_server_config = {
             'pattoo_db': {
                 'db_pool_size': 10,
@@ -137,9 +162,16 @@ class TestConfigure(unittest.TestCase):
             with open(file_path, 'w+') as temp_config:
                 yaml.dump(expected, temp_config, default_flow_style=False)
             config = configure.read_config(file_path, expected)
-            result = config == expected
-            self.assertEqual(result, True)
+            #result = config == expected
+            self.assertEqual(config, expected)
 
+            # Test find and replace
+            with self.subTest():
+                expected = self.custom_config
+                config = configure.read_config(file_path, expected)
+                print(f'\n\nConfigurtion is: {config}\n\n')
+                print(f'\n\nExpected is: {expected}\n\n')
+                self.assertEqual(config, expected)
     def test_pattoo_config_server(self):
         """Unittest to test the pattoo_config function for the pattoo server."""
         # Initialize key variables

--- a/tests/test_pattoo_shared/installation/test_configure.py
+++ b/tests/test_pattoo_shared/installation/test_configure.py
@@ -162,16 +162,14 @@ class TestConfigure(unittest.TestCase):
             with open(file_path, 'w+') as temp_config:
                 yaml.dump(expected, temp_config, default_flow_style=False)
             config = configure.read_config(file_path, expected)
-            #result = config == expected
             self.assertEqual(config, expected)
 
             # Test find and replace
             with self.subTest():
                 expected = self.custom_config
                 config = configure.read_config(file_path, expected)
-                print(f'\n\nConfigurtion is: {config}\n\n')
-                print(f'\n\nExpected is: {expected}\n\n')
                 self.assertEqual(config, expected)
+
     def test_pattoo_config_server(self):
         """Unittest to test the pattoo_config function for the pattoo server."""
         # Initialize key variables
@@ -288,6 +286,19 @@ pattoo_web_api:
             # Retrieve config dict from yaml file
             result = configure.read_config(file_path, expected)
             self.assertEqual(result, expected)
+
+            # Test if file gets overwritten
+            with self.subTest():
+                expected = self.custom_config
+                # Create config file
+                configure.pattoo_config('pattoo', temp_dir, expected)
+
+                # Retrieve config dict from yaml file
+                result = configure.read_config(file_path, expected)
+                self.assertEqual(result, expected)
+
+
+
 
     # Using mock patch to capture output
     @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)

--- a/tests/test_pattoo_shared/installation/test_configure.py
+++ b/tests/test_pattoo_shared/installation/test_configure.py
@@ -297,9 +297,6 @@ pattoo_web_api:
                 result = configure.read_config(file_path, expected)
                 self.assertEqual(result, expected)
 
-
-
-
     # Using mock patch to capture output
     @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
     def test_check_config(self, mock_stdout):


### PR DESCRIPTION
- Ensured that read_config actually rewrites the file and added unittests 
- Fixed verbose mode for run_script to disable error messages unless the verbose flag is triggered